### PR TITLE
Fix error propogation during cancellation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -116,5 +116,8 @@ StatementMacros:
   - QT_REQUIRE_VERSION
 TabWidth:        4
 UseTab:          Never
+WhitespaceSensitiveMacros:
+ - EM_ASM
+ - EM_JS
 ...
 

--- a/include/coro/core/awaitable.hpp
+++ b/include/coro/core/awaitable.hpp
@@ -65,6 +65,11 @@ struct Awaitable {
     Return await_resume() {
         // eagerly destroy completed task at the end of the scope
         detail::AtExit exit {[this]() noexcept { _task.reset(); }};
+
+        // throw if stop was requested
+        auto& taskPromise = _task.promise();
+        taskPromise.continuation.throwIfStopped();
+
         if constexpr (std::is_move_constructible_v<Return>) {
             return std::move(_task.promise()).value();
         } else {

--- a/include/coro/core/handle.hpp
+++ b/include/coro/core/handle.hpp
@@ -53,6 +53,9 @@ public:
     void resume();
 
 public:
+    void throwIfStopped();
+
+public:
     /// Returns whether stored handle is non null.
     explicit operator bool() const;
 

--- a/include/coro/core/handle.inl.hpp
+++ b/include/coro/core/handle.inl.hpp
@@ -86,6 +86,10 @@ inline void CoroHandle::resume() {
     _handle.resume();
 }
 
+inline void CoroHandle::throwIfStopped() {
+    promise().context.stopToken.throwIfStopped();
+}
+
 inline CoroHandle::operator bool() const {
     return static_cast<bool>(_handle);
 }

--- a/include/coro/core/stop.hpp
+++ b/include/coro/core/stop.hpp
@@ -90,8 +90,12 @@ public:
 
     void throwIfStopped() const {
         if (stopRequested()) {
-            std::rethrow_exception(exception());
+            throwException();
         }
+    }
+
+    void throwException() const {
+        std::rethrow_exception(exception());
     }
 
     std::exception_ptr exception() const {

--- a/include/coro/emscripten/executor.hpp
+++ b/include/coro/emscripten/executor.hpp
@@ -148,7 +148,7 @@ private:
 
         void external(CoroHandle&& handle) {
             auto& promise = handle.promise();
-            auto callback = Callback::create([handle]() mutable { handle.promise().skipExecution(); });
+            auto callback = Callback::create([handle]() mutable { handle.promise().executor->schedule(handle); });
             externals.emplace(std::move(handle), callback);
             promise.context.stopToken.addStopCallback(callback);
         }
@@ -174,7 +174,7 @@ private:
                 }
                 continue;
             }
-            if (next.promise().skipExecution()) [[unlikely]] {
+            if (next.promise().finished()) [[unlikely]] {
                 continue;
             }
             ++opCount;

--- a/include/coro/sync/pipe.hpp
+++ b/include/coro/sync/pipe.hpp
@@ -87,7 +87,8 @@ public:
         return true;
     }
 
-    T await_resume() noexcept {
+    T await_resume() {
+        _continuation.throwIfStopped();
         return std::move(_data).value();
     }
 

--- a/tests/linux/stop.cpp
+++ b/tests/linux/stop.cpp
@@ -4,51 +4,88 @@
 
 #include <gtest/gtest.h>
 
-coro::Task<void> simple0() {
-    using namespace std::chrono_literals;
-    co_await coro::sleep(100);
-    auto stop = co_await coro::currentStopToken;
-    stop.throwIfStopped();
-    co_return;
+struct Cancelled {};
+
+int exceptions[5][3] = {{0}, {0}, {0}};
+
+coro::Task<void> simple0(const int idx) {
+    try {
+        using namespace std::chrono_literals;
+        co_await coro::sleep(100);
+    } catch (const coro::StopError&) {
+        ++exceptions[idx][0];
+    } catch (const Cancelled&) {
+        ++exceptions[idx][0];
+    } catch (...) {
+        EXPECT_FALSE("Invalid exception was thrown.");
+    }
 }
 
-coro::Task<int> simple1() {
-    co_await simple0();
-    co_return 1;
+coro::Task<int> simple1(const int idx) {
+    try {
+        co_await simple0(idx);
+        co_return 1;
+    } catch (const coro::StopError&) {
+        ++exceptions[idx][1];
+    } catch (const Cancelled&) {
+        ++exceptions[idx][1];
+    } catch (...) {
+        EXPECT_FALSE("Invalid exception was thrown.");
+    }
+    co_return 2;
 }
 
-coro::Task<int> simple2() {
-    int x = co_await simple1();
-    co_return x + 1;
+coro::Task<int> simple2(const int idx) {
+    try {
+        co_await simple0(idx);
+        co_return 2;
+    } catch (const coro::StopError&) {
+        ++exceptions[idx][2];
+    } catch (const Cancelled&) {
+        ++exceptions[idx][2];
+    } catch (...) {
+        EXPECT_FALSE("Invalid exception was thrown.");
+    }
+    co_return 3;
 }
 
-coro::Task<double> simple() {
-    int x1 = co_await simple1();
-    int x2 = co_await simple2();
+coro::Task<double> simple(const int idx) {
+    int x1 = co_await simple1(idx);
+    int x2 = co_await simple2(idx);
     co_return static_cast<double>(x1) / static_cast<double>(x2);
 }
 
-struct Cancelled {};
-
 TEST(Stop, Normal) {
-    coro::StopSource ss1;
-    coro::StopSource ss2 {std::make_exception_ptr(Cancelled {})};
-    coro::StopSource ss3;
+    coro::StopSource ss0;
+    coro::StopSource ss1 {std::make_exception_ptr(Cancelled {})};
+    coro::StopSource ss2;
 
     auto executor = coro::SerialExecutor::create();
-    auto task1 = simple();
-    task1.setStopToken(ss1.token());
-    auto future1 = executor->future(std::move(task1));
+    auto task0 = simple(0);
+    task0.setStopToken(ss0.token());
+    auto future0 = executor->future(std::move(task0));
+    auto future1 = executor->future(simple(1).setStopToken(ss1.token()));
+    auto future2 = executor->future(simple(2).setStopToken(ss2.token()));
 
-    auto future2 = executor->future(simple().setStopToken(ss2.token()));
-    auto future3 = executor->future(simple().setStopToken(ss3.token()));
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(70ms);
+    ss0.requestStop();
+    EXPECT_THROW(future0.get(), coro::StopError);
+    EXPECT_EQ(exceptions[0][0], 1);
+    EXPECT_EQ(exceptions[0][1], 1);
+    EXPECT_EQ(exceptions[0][2], 0);
 
+    std::this_thread::sleep_for(70ms);
     ss1.requestStop();
-    ss2.requestStop();
+    EXPECT_THROW(future1.get(), Cancelled);
+    EXPECT_EQ(exceptions[1][0], 1);
+    EXPECT_EQ(exceptions[1][1], 0);
+    EXPECT_EQ(exceptions[1][2], 1);
 
-    EXPECT_THROW(future1.get(), coro::StopError);
-    EXPECT_THROW(future2.get(), Cancelled);
-    EXPECT_DOUBLE_EQ(future3.get(), 0.5);
+    EXPECT_DOUBLE_EQ(future2.get(), 0.5);
+    EXPECT_EQ(exceptions[2][0], 0);
+    EXPECT_EQ(exceptions[2][1], 0);
+    EXPECT_EQ(exceptions[2][2], 0);
 }
 
 TEST(Stop, StoppedToken) {
@@ -56,13 +93,17 @@ TEST(Stop, StoppedToken) {
     ss.requestStop();
 
     auto executor = coro::SerialExecutor::create();
-    auto task1 = simple();
-    task1.setStopToken(ss.token());
-    executor->schedule(std::move(task1));
+    auto task3 = simple(3);
+    task3.setStopToken(ss.token());
+    // not getting the result does not throw
+    executor->schedule(std::move(task3));
 
-    auto task2 = simple();
+    auto task2 = simple(4);
     task2.setStopToken(ss.token());
     auto future = executor->future(std::move(task2));
 
     EXPECT_THROW(future.get(), coro::StopError);
+    EXPECT_EQ(exceptions[4][0], 1);
+    EXPECT_EQ(exceptions[4][1], 1);
+    EXPECT_EQ(exceptions[4][2], 0);
 }

--- a/tests/wasm/tests/simple.test.js
+++ b/tests/wasm/tests/simple.test.js
@@ -58,3 +58,7 @@ test("AbortController", async () => {
     expect(await coro.testAbortController()).toBe(42);
     expect(await coro.testAbortControllerTimeout()).toBe(42);
 })
+
+test("CustomPromiseCancellation", async () => {
+    await coro.testCustomPromiseCancellation();
+})


### PR DESCRIPTION
- The previous implementation was not propogating exception through deepmost coroutine frame in call hierarchy when cancellation request was sent. New implementation fixes that and additionaly simplifies the cancellation exception propagation, which is now checked and thrown at await_resume() points.
- With this change responsibility of checking for the cancellation is shifted from executable to awaitables.
- Now cancellation request also cancels coroutines stuck waiting for a custom JS promises. It does so by cancelling coro frame awaiting for JS promise and disconnecting JS promise from executor, so nothing fancy happens when the promise is finally fulfilled.
- Upgraded emsdk to 4.0.10 which contains emscripten coroutine error propogation fixes.
- Added unit tests to ensure error propogation through deepmost coroutine.