### PR TITLE
Bug fixes and improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,72 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: wasm
+            preset: coro:wasm
+            build_dir: build/wasm
+            test_preset: tests:wasm
+            cmake_args: ""
+          - name: linux-asan
+            preset: coro
+            build_dir: build/Linux
+            test_preset: tests
+            cmake_args: "-DCORO_SANITIZE=address"
+          - name: linux-leak
+            preset: coro
+            build_dir: build/Linux
+            test_preset: tests
+            cmake_args: "-DCORO_SANITIZE=leak"
+          - name: linux-tsan
+            preset: coro
+            build_dir: build/Linux
+            test_preset: tests
+            cmake_args: "-DCORO_SANITIZE=thread"
+
+    steps:
+      - name: Install LLVM 17
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 17 all
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Prepare emscripten
+        if: matrix.name == 'wasm'
+        working-directory: third_party/emsdk
+        run: ./emsdk install 4.0.10 && ./emsdk activate 4.0.10
+
+      - name: Prepare WASM dependencies
+        if: matrix.name == 'wasm'
+        working-directory: tests/wasm
+        run: npm ci
+
+      - name: Configure CMake
+        env:
+          CC: clang-17
+          CXX: clang++-17
+        run: |
+          cmake --preset ${{ matrix.preset }} ${{ matrix.cmake_args }}
+
+      - name: Build
+        run: |
+          cmake --build ${{ matrix.build_dir }}
+
+      - name: Run tests
+        run: |
+          ctest --preset ${{ matrix.test_preset }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,28 +32,29 @@ if(EMSCRIPTEN)
 endif()
 
 if(CORO_TESTS)
-    option(CORO_SANITIZE_ASAN_AND_UBSAN "Enable ASan and UBSan." ON)
-    option(CORO_SANITIZE_TSAN "Enable TSan." OFF)
-
     target_compile_options(coro INTERFACE -Wall -Wextra -Wnewline-eof -Wformat -Werror)
 
-    set(SANITIZERS "")
+    set(CORO_SANITIZE "off" CACHE STRING "Sanitize tests with 'address', 'leak' or 'thread'")
+    set_property(CACHE CORO_SANITIZE PROPERTY STRINGS "off" "address" "leak" "thread")
 
-    if(CORO_SANITIZE_TSAN AND CORO_SANITIZE_ASAN_AND_UBSAN)
-        message(FATAL_ERROR "TSan is incompatible with ASan/UBSan. Use separate builds.")
+    string(TOUPPER "${CORO_SANITIZE}" CORO_SANITIZE)
+
+    set(SANITIZER_FLAGS "")
+
+    if(CORO_SANITIZE STREQUAL "ADDRESS")
+        message(STATUS "Enabling address sanitizer")
+        set(SANITIZER_FLAGS -fsanitize=address,undefined)
+    elseif(CORO_SANITIZE STREQUAL "LEAK")
+        message(STATUS "Enabling leak sanitizer")
+        set(SANITIZER_FLAGS -fsanitize=leak)
+    elseif(CORO_SANITIZE STREQUAL "THREAD")
+        message(STATUS "Enabling thread sanitizer")
+        set(SANITIZER_FLAGS -fsanitize=thread)
     endif()
 
-    if(CORO_SANITIZE_ASAN_AND_UBSAN)
-        set(SANITIZERS ${SANITIZERS} -fsanitize=address,undefined)
-    endif()
-
-    if(CORO_SANITIZE_TSAN)
-        set(SANITIZERS ${SANITIZERS} -fsanitize=thread)
-    endif()
-
-    if(SANITIZERS)
-        target_compile_options(coro INTERFACE ${SANITIZERS})
-        target_link_options(coro INTERFACE ${SANITIZERS})
+    if(SANITIZER_FLAGS)
+        target_compile_options(coro INTERFACE ${SANITIZER_FLAGS})
+        target_link_options(coro INTERFACE ${SANITIZER_FLAGS})
     endif()
 
     enable_testing()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -59,7 +59,7 @@
     {
       "name": "tests:wasm",
       "displayName": "Unit Tests for wasm.",
-      "configurePreset": "coro",
+      "configurePreset": "coro:wasm",
       "output": {
         "outputOnFailure": true
       },

--- a/include/coro/core/awaitable.hpp
+++ b/include/coro/core/awaitable.hpp
@@ -12,7 +12,10 @@ template <typename R>
 struct ReadyAwaitable {
     R result;
 
-    ReadyAwaitable(R r)
+    ReadyAwaitable(const R& r)
+        : result(r) {}
+
+    ReadyAwaitable(R&& r)
         : result(std::move(r)) {}
 
     bool await_ready() noexcept {
@@ -26,6 +29,24 @@ struct ReadyAwaitable {
         } else {
             return result;
         }
+    }
+};
+
+template <typename R>
+struct ReadyAwaitable<R&> {
+    R& result;
+
+    ReadyAwaitable(R& r)
+        : result(r) {}
+
+    bool await_ready() noexcept {
+        return true;
+    }
+
+    void await_suspend(std::coroutine_handle<>) noexcept {}
+
+    R& await_resume() {
+        return result;
     }
 };
 

--- a/include/coro/core/stop.hpp
+++ b/include/coro/core/stop.hpp
@@ -35,6 +35,7 @@ public:
 public:
     void requestStop() noexcept {
         std::scoped_lock lock {_mutex};
+        _stopRequested.store(true);
         auto callbacks = std::move(_callbacks);
         for (const auto& weakCB : callbacks) {
             auto callback = weakCB.lock();
@@ -42,7 +43,6 @@ public:
                 callback->invoke();
             }
         }
-        _stopRequested.store(true);
     }
 
     bool stopRequested() const noexcept {
@@ -100,6 +100,10 @@ public:
 
     std::exception_ptr exception() const {
         return _state->exception();
+    }
+
+    void reset() {
+        _state.reset();
     }
 
 public:

--- a/include/coro/core/task.hpp
+++ b/include/coro/core/task.hpp
@@ -74,6 +74,19 @@ public:
         return std::move(*this);
     }
 
+    const TaskContext& context() const {
+        return promise().context;
+    }
+
+    void setContext(const TaskContext& context) & {
+        promise().context = context;
+    }
+
+    Task&& setContext(const TaskContext& context) && {
+        promise().context = context;
+        return std::move(*this);
+    }
+
     CoroHandle handle() const {
         return _handle;
     }

--- a/include/coro/detail/sleep.hpp
+++ b/include/coro/detail/sleep.hpp
@@ -14,7 +14,7 @@ namespace detail {
 
 class TimedScheduler {
 public:
-    using Clock = std::chrono::high_resolution_clock;
+    using Clock = std::chrono::steady_clock;
     using TimePoint = Clock::time_point;
 
     TimedScheduler() {

--- a/include/coro/emscripten/sleep.hpp
+++ b/include/coro/emscripten/sleep.hpp
@@ -27,6 +27,7 @@ public:
     emscripten::val await_resume() {
         if (_token.stopRequested()) {
             _sleep.call<void>("cancel");
+            _token.throwException();
         }
         return ValAwaitable::await_resume();
     }

--- a/include/coro/executors/serial_executor.hpp
+++ b/include/coro/executors/serial_executor.hpp
@@ -112,9 +112,6 @@ private:
             {
                 std::scoped_lock lock {mutex};
                 externals.erase(handle);
-                if (handle.promise().finished()) [[unlikely]] {
-                    return;
-                }
                 tasks.pushFront(std::move(handle));
             }
             cv.notify_one();
@@ -124,9 +121,6 @@ private:
             {
                 std::scoped_lock lock {mutex};
                 externals.erase(handle);
-                if (handle.promise().finished()) [[unlikely]] {
-                    return;
-                }
                 tasks.pushBack(std::move(handle));
             }
             cv.notify_one();

--- a/tests/linux/latch.cpp
+++ b/tests/linux/latch.cpp
@@ -10,12 +10,12 @@ coro::Task<int> work() {
     co_return 42;
 }
 
-coro::Task<int> consumer(coro::Latch& latch) {
+coro::Task<int> consumer(coro::Latch latch) {
     co_await latch;
     co_return co_await work();
 }
 
-coro::Task<int> producer(coro::Latch& latch) {
+coro::Task<int> producer(coro::Latch latch) {
     auto result = co_await work();
     latch.count_down();
     co_return result;


### PR DESCRIPTION
- Add API to get/set TaskContext from/to Task
- Add currentContext ReadyAwaitable allowing to get access to the task
  context from inside the coroutine function.
- Add currentPromise ReadyAwaitable giving access to the PromiseBase of
  the current coroutine. It gives read/write access for advanced use
  cases, and is used in coro::all to severe connection to the StopToken.
- Refactor Latch so that it stores all necessary information in the
  shared internal state, and now it can be passed around via copying and
  will retain shared ownership of the state.
- Fix bug in coro::all, when during cancellation it was awakening from
  latch sleep and cancelling without waiting for the child coroutines,
  thus leaving some of the pointers passed to the child coroutines
  dangling. Now coro::all correctly passes StopToken to the child
  coroutines and severes its connection with StopToken, thus waiting for
  all children's cancellation before cancelling itself.
- Fix a strange decision to fire StopToken callbacks before setting
  stop requested state to true. Now stopped state is true inside the
  callbacks.
- Fix possible deadlock reported by thread sanitizer on linux. Now we do
  not check if the task was finished during scheduling, leaving that
  check to only be checked in the execution loop, where the
  SerialExecutor's state mutex is unlocked during task.resume().
- Add github actions to run unit tests on PR(s) and master push.