### PR TITLE
Allow users to register exception translators

### DIFF
--- a/include/coro/emscripten/exception.hpp
+++ b/include/coro/emscripten/exception.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <exception>
+#include <functional>
+#include <list>
+
+#include <emscripten/val.h>
+
+extern "C" emscripten::EM_VAL _coro_lib_val_from_cpp_exception();
+
+namespace coro {
+
+using ExceptionTranslator = std::function<emscripten::val(std::exception_ptr)>;
+
+namespace detail {
+
+inline std::list<ExceptionTranslator>& translators() {
+    static std::list<ExceptionTranslator> instance;
+    return instance;
+}
+
+inline emscripten::val defaultTranslator(std::exception_ptr eptr) {
+    try {
+        std::rethrow_exception(eptr);
+    } catch (...) {
+        return emscripten::val::take_ownership(_coro_lib_val_from_cpp_exception());
+    }
+}
+
+} // namespace detail
+
+inline void registerExceptionTranslator(ExceptionTranslator translator) {
+    detail::translators().push_back(std::move(translator));
+}
+
+inline emscripten::val translateException(std::exception_ptr eptr) {
+    auto& translators = detail::translators();
+    for (auto& translator : translators) {
+        emscripten::val error;
+        try {
+            // In case if one of the translators is poorly written and rethrows we consider it as not translated
+            error = translator(eptr);
+        } catch (...) {
+        }
+        if (!error.isUndefined()) {
+            return error;
+        }
+    }
+    return detail::defaultTranslator(eptr);
+}
+
+} // namespace coro

--- a/include/coro/emscripten/executor.hpp
+++ b/include/coro/emscripten/executor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "exception.hpp"
 #include "js_promise.hpp"
 #include "sleep.hpp"
 
@@ -13,10 +14,6 @@
 #include <emscripten/val.h>
 
 namespace coro {
-
-namespace detail {
-extern "C" emscripten::EM_VAL _coro_lib_val_from_cpp_exception();
-} // namespace detail
 
 /**
  * Single threaded serial executor designed specifically for working in emscripten environment.
@@ -75,7 +72,7 @@ public:
                     promise.resolve(std::move(result));
                 }
             } catch (...) {
-                auto error = emscripten::val::take_ownership(detail::_coro_lib_val_from_cpp_exception());
+                auto error = translateException(std::current_exception());
                 promise.reject(std::move(error));
             }
         }(std::move(task), std::move(promise));

--- a/tests/wasm/bindings.cpp
+++ b/tests/wasm/bindings.cpp
@@ -7,6 +7,11 @@
 #include <coro/emscripten/abort.hpp>
 #include <coro/emscripten/executor.hpp>
 #include <coro/emscripten/bridge.hpp>
+#include <coro/emscripten/exception.hpp>
+
+struct CustomError : std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
 
 template <size_t N>
 coro::Task<int> sleepy(bool thr) {
@@ -17,7 +22,7 @@ template <>
 coro::Task<int> sleepy<0>(bool thr) {
     co_await coro::sleep(200);
     if (thr) {
-        throw std::runtime_error {"test error"};
+        throw CustomError {"test error"};
     }
     co_return 42;
 }
@@ -163,9 +168,26 @@ coro::Task<void> testCustomPromiseCancellation() {
     co_await promise;
 }
 
+void registerExceptionTranslator() {
+    coro::registerExceptionTranslator([](std::exception_ptr eptr) -> emscripten::val {
+        try {
+            std::rethrow_exception(eptr);
+        } catch (const CustomError& e) {
+            auto errClass = emscripten::val::global("CustomError");
+            if (!errClass.isUndefined()) {
+                const std::string message {e.what()};
+                return errClass.new_(message);
+            }
+        } catch (...) {
+        }
+        return emscripten::val::undefined();
+    });
+}
+
 EMSCRIPTEN_BINDINGS(Test) {
     emscripten::function("sleepyTask", +[]() { return coro::taskPromise(sleepy<5>(false)); });
     emscripten::function("failingTask", +[]() { return coro::taskPromise(sleepy<5>(true)); });
+    emscripten::function("registerExceptionTranslator", &registerExceptionTranslator);
     emscripten::function(
         "lifetimeTask", +[]() {
             auto executor = TestExecutor::create();

--- a/tests/wasm/tests/simple.test.js
+++ b/tests/wasm/tests/simple.test.js
@@ -15,6 +15,15 @@ test("Simple", async () => {
     expect(answer).toBe(42);
 })
 
+class CustomError extends Error {
+    constructor(msg) {
+        super(msg)
+        this.name = "CustomError";
+    }
+}
+
+globalThis.CustomError = CustomError;
+
 test("Exception", async () => {
     await coro.failingTask().then(
         result => {
@@ -22,7 +31,18 @@ test("Exception", async () => {
         },
         error => {
             expect(error).toBeInstanceOf(WebAssembly.Exception);
-            expect(error.message).toStrictEqual(["std::runtime_error", "test error"]);
+            expect(error.message).toStrictEqual(["CustomError", "test error"]);
+        }
+    )
+    coro.registerExceptionTranslator();
+    await coro.failingTask().then(
+        result => {
+            throw new Error(`The failingTask should throw, but got result: ${result}`);
+        },
+        error => {
+            expect(error).toBeInstanceOf(CustomError);
+            expect(error.name).toStrictEqual("CustomError");
+            expect(error.message).toStrictEqual("test error");
         }
     )
 })


### PR DESCRIPTION
- Add API allowing users to add translators to translate C++ exceptions into the JS Error types at the last stage of execution when error is passed to the JS promise as a rejection value.