### PR TITLE
 Add thin wrapper for webgpu

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -35,21 +35,28 @@ jobs:
             cmake_args: "-DCORO_SANITIZE=thread"
 
     steps:
-      - name: Install LLVM 17
+      - name: Install LLVM 21
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 17 all
+          sudo ./llvm.sh 21 all
 
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
+      # Dawn's Vulkan backend needs a driver; runners have no GPU, so install
+      # lavapipe (Mesa's software Vulkan implementation). Without it Dawn
+      # falls back to its null backend, which no-ops all GPU work.
+      - name: Install software Vulkan driver
+        if: matrix.name != 'wasm'
+        run: sudo apt-get update && sudo apt-get install -y mesa-vulkan-drivers
+
       - name: Prepare emscripten
         if: matrix.name == 'wasm'
         working-directory: third_party/emsdk
-        run: ./emsdk install 4.0.10 && ./emsdk activate 4.0.10
+        run: ./emsdk install 4.0.23 && ./emsdk activate 4.0.23
 
       - name: Prepare WASM dependencies
         if: matrix.name == 'wasm'
@@ -58,8 +65,8 @@ jobs:
 
       - name: Configure CMake
         env:
-          CC: clang-17
-          CXX: clang++-17
+          CC: clang-21
+          CXX: clang++-21
         run: |
           cmake --preset ${{ matrix.preset }} ${{ matrix.cmake_args }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .cache/
 compile_commands.json
+third_party/dawn/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,16 @@ if(CORO_TESTS)
         target_link_options(coro INTERFACE ${SANITIZER_FLAGS})
     endif()
 
+
+    if(EMSCRIPTEN)
+        # Make IDE happy
+        include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/third_party/emsdk/upstream/emscripten/cache/ports/emdawnwebgpu/emdawnwebgpu_pkg/webgpu_cpp/include)
+        include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/third_party/emsdk/upstream/emscripten/cache/ports/emdawnwebgpu/emdawnwebgpu_pkg/webgpu/include)
+    else()
+        include(${CMAKE_CURRENT_SOURCE_DIR}/third_party/FetchDawn.cmake)
+    endif()
+
     enable_testing()
-    add_subdirectory(tests)
     add_subdirectory(third_party)
+    add_subdirectory(tests)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,7 +27,7 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "CORO_TESTS": "ON",
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/third_party/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake",
-        "CMAKE_CROSSCOMPILING_EMULATOR": "${sourceDir}/third_party/emsdk/node/20.18.0_64bit/bin/node"
+        "CMAKE_CROSSCOMPILING_EMULATOR": "${sourceDir}/third_party/emsdk/node/22.16.0_64bit/bin/node"
       }
     }
   ],

--- a/include/coro/helpers/webgpu_cpp.h
+++ b/include/coro/helpers/webgpu_cpp.h
@@ -1,0 +1,246 @@
+#pragma once
+
+#include <webgpu/webgpu_cpp.h>
+
+#include "../core/task.hpp"
+#include "../sync/latch.hpp"
+
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace coro::wgpu {
+
+class Error : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+inline coro::Task<::wgpu::Adapter> RequestAdapter(::wgpu::Instance instance,
+                                                  ::wgpu::RequestAdapterOptions const* options = nullptr) {
+    Latch latch {1};
+    ::wgpu::Adapter result;
+    std::exception_ptr eptr = nullptr;
+    instance.RequestAdapter(options,
+                            ::wgpu::CallbackMode::AllowSpontaneous,
+                            [&](::wgpu::RequestAdapterStatus status, ::wgpu::Adapter adapter, const char* message) {
+                                switch (status) {
+                                case ::wgpu::RequestAdapterStatus::Success:
+                                    result = std::move(adapter);
+                                    break;
+                                case ::wgpu::RequestAdapterStatus::CallbackCancelled:
+                                case ::wgpu::RequestAdapterStatus::Unavailable:
+                                case ::wgpu::RequestAdapterStatus::Error:
+                                    eptr = std::make_exception_ptr(Error {message});
+                                    break;
+                                }
+                                latch.count_down();
+                            });
+    co_await latch;
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+    co_return result;
+}
+
+inline coro::Task<::wgpu::Device> RequestDevice(::wgpu::Adapter adapter,
+                                                ::wgpu::DeviceDescriptor const* descriptor = nullptr) {
+    Latch latch {1};
+    ::wgpu::Device result;
+    std::exception_ptr eptr = nullptr;
+    adapter.RequestDevice(descriptor,
+                          ::wgpu::CallbackMode::AllowSpontaneous,
+                          [&](::wgpu::RequestDeviceStatus status, ::wgpu::Device device, const char* message) {
+                              switch (status) {
+                              case ::wgpu::RequestDeviceStatus::Success:
+                                  result = std::move(device);
+                                  break;
+                              case ::wgpu::RequestDeviceStatus::CallbackCancelled:
+                              case ::wgpu::RequestDeviceStatus::Error:
+                                  eptr = std::make_exception_ptr(Error {message});
+                                  break;
+                              }
+                              latch.count_down();
+                          });
+    co_await latch;
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+    co_return result;
+}
+
+inline coro::Task<void> MapAsync(::wgpu::Buffer buffer, ::wgpu::MapMode mode, std::size_t offset, std::size_t size) {
+    Latch latch {1};
+    std::exception_ptr eptr = nullptr;
+    buffer.MapAsync(mode,
+                    offset,
+                    size,
+                    ::wgpu::CallbackMode::AllowSpontaneous,
+                    [&](::wgpu::MapAsyncStatus status, const char* message) {
+                        switch (status) {
+                        case ::wgpu::MapAsyncStatus::Success:
+                            break;
+                        case ::wgpu::MapAsyncStatus::CallbackCancelled:
+                        case ::wgpu::MapAsyncStatus::Error:
+                        case ::wgpu::MapAsyncStatus::Aborted:
+                            eptr = std::make_exception_ptr(Error {message});
+                            break;
+                        }
+                        latch.count_down();
+                    });
+    co_await latch;
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+}
+
+inline coro::Task<void> OnSubmittedWorkDone(::wgpu::Queue queue) {
+    Latch latch {1};
+    std::exception_ptr eptr = nullptr;
+    queue.OnSubmittedWorkDone(::wgpu::CallbackMode::AllowSpontaneous,
+                              [&](::wgpu::QueueWorkDoneStatus status, const char* message) {
+                                  switch (status) {
+                                  case ::wgpu::QueueWorkDoneStatus::Success:
+                                      break;
+                                  case ::wgpu::QueueWorkDoneStatus::CallbackCancelled:
+                                  case ::wgpu::QueueWorkDoneStatus::Error:
+                                      eptr = std::make_exception_ptr(Error {message});
+                                      break;
+                                  }
+                                  latch.count_down();
+                              });
+    co_await latch;
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+}
+
+/// co_return is the ErrorType captured by the popped scope (NoError when the
+/// scope was clean). A non-Success PopErrorScopeStatus means the pop itself
+/// failed and is thrown as Error.
+inline coro::Task<::wgpu::ErrorType> PopErrorScope(::wgpu::Device device) {
+    Latch latch {1};
+    ::wgpu::ErrorType result {};
+    std::exception_ptr eptr = nullptr;
+    device.PopErrorScope(::wgpu::CallbackMode::AllowSpontaneous,
+                         [&](::wgpu::PopErrorScopeStatus status, ::wgpu::ErrorType type, const char* message) {
+                             switch (status) {
+                             case ::wgpu::PopErrorScopeStatus::Success:
+                                 result = type;
+                                 break;
+                             case ::wgpu::PopErrorScopeStatus::CallbackCancelled:
+                             case ::wgpu::PopErrorScopeStatus::Error:
+                                 eptr = std::make_exception_ptr(Error {message});
+                                 break;
+                             }
+                             latch.count_down();
+                         });
+    co_await latch;
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+    co_return result;
+}
+
+/// Returns the shader's compilation diagnostics as {errors, warnings + info}.
+/// Each message is formatted as "line:pos: text" on its own line; messages in
+/// the second string are additionally prefixed with their severity. Both
+/// strings are empty on a clean compile. The CompilationInfo Dawn delivers is
+/// only valid inside the callback, so the text is copied out here.
+inline coro::Task<std::pair<std::string, std::string>> GetCompilationInfo(::wgpu::ShaderModule shaderModule) {
+    Latch latch {1};
+    std::pair<std::string, std::string> result;
+    std::exception_ptr eptr = nullptr;
+    shaderModule.GetCompilationInfo(
+        ::wgpu::CallbackMode::AllowSpontaneous,
+        [&](::wgpu::CompilationInfoRequestStatus status, ::wgpu::CompilationInfo const* info) {
+            switch (status) {
+            case ::wgpu::CompilationInfoRequestStatus::Success:
+                for (std::size_t i = 0; i < info->messageCount; ++i) {
+                    const auto& message = info->messages[i];
+                    const bool isError = message.type == ::wgpu::CompilationMessageType::Error;
+                    std::string& out = isError ? result.first : result.second;
+                    if (isError) {
+                        out += "error ";
+                    } else {
+                        out += message.type == ::wgpu::CompilationMessageType::Warning ? "warning " : "info ";
+                    }
+                    out += std::to_string(message.lineNum);
+                    out += ':';
+                    out += std::to_string(message.linePos);
+                    out += ": ";
+                    out += std::string_view {message.message};
+                    out += '\n';
+                }
+                break;
+            case ::wgpu::CompilationInfoRequestStatus::CallbackCancelled:
+                eptr = std::make_exception_ptr(Error {"compilation info request was cancelled"});
+                break;
+            }
+            latch.count_down();
+        });
+    co_await latch;
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+    co_return result;
+}
+
+inline coro::Task<::wgpu::ComputePipeline>
+CreateComputePipelineAsync(::wgpu::Device device, ::wgpu::ComputePipelineDescriptor const* descriptor) {
+    Latch latch {1};
+    ::wgpu::ComputePipeline result;
+    std::exception_ptr eptr = nullptr;
+    device.CreateComputePipelineAsync(
+        descriptor,
+        ::wgpu::CallbackMode::AllowSpontaneous,
+        [&](::wgpu::CreatePipelineAsyncStatus status, ::wgpu::ComputePipeline pipeline, const char* message) {
+            switch (status) {
+            case ::wgpu::CreatePipelineAsyncStatus::Success:
+                result = std::move(pipeline);
+                break;
+            case ::wgpu::CreatePipelineAsyncStatus::CallbackCancelled:
+            case ::wgpu::CreatePipelineAsyncStatus::ValidationError:
+            case ::wgpu::CreatePipelineAsyncStatus::InternalError:
+                eptr = std::make_exception_ptr(Error {message});
+                break;
+            }
+            latch.count_down();
+        });
+    co_await latch;
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+    co_return result;
+}
+
+inline coro::Task<::wgpu::RenderPipeline>
+CreateRenderPipelineAsync(::wgpu::Device device, ::wgpu::RenderPipelineDescriptor const* descriptor) {
+    Latch latch {1};
+    ::wgpu::RenderPipeline result;
+    std::exception_ptr eptr = nullptr;
+    device.CreateRenderPipelineAsync(
+        descriptor,
+        ::wgpu::CallbackMode::AllowSpontaneous,
+        [&](::wgpu::CreatePipelineAsyncStatus status, ::wgpu::RenderPipeline pipeline, const char* message) {
+            switch (status) {
+            case ::wgpu::CreatePipelineAsyncStatus::Success:
+                result = std::move(pipeline);
+                break;
+            case ::wgpu::CreatePipelineAsyncStatus::CallbackCancelled:
+            case ::wgpu::CreatePipelineAsyncStatus::ValidationError:
+            case ::wgpu::CreatePipelineAsyncStatus::InternalError:
+                eptr = std::make_exception_ptr(Error {message});
+                break;
+            }
+            latch.count_down();
+        });
+    co_await latch;
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+    co_return result;
+}
+
+} // namespace coro::wgpu

--- a/tests/linux/CMakeLists.txt
+++ b/tests/linux/CMakeLists.txt
@@ -44,3 +44,8 @@ add_executable(pipe pipe.cpp)
 target_link_libraries(pipe coro gtest_main)
 add_test(NAME pipe COMMAND pipe)
 set_tests_properties(pipe PROPERTIES TIMEOUT 2)
+
+add_executable(webgpu webgpu.cpp)
+target_link_libraries(webgpu coro gtest_main dawn::webgpu_dawn)
+add_test(NAME webgpu COMMAND webgpu)
+set_tests_properties(webgpu PROPERTIES TIMEOUT 30)

--- a/tests/linux/webgpu.cpp
+++ b/tests/linux/webgpu.cpp
@@ -1,0 +1,91 @@
+#include <coro/coro.hpp>
+#include <coro/sleep.hpp>
+#include <coro/executors/serial_executor.hpp>
+#include <coro/helpers/webgpu_cpp.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+namespace {
+
+coro::Task<void> pumpEvents(wgpu::Instance instance, bool& done) {
+    while (!done) {
+        instance.ProcessEvents();
+        co_await coro::sleep(10);
+    }
+}
+
+coro::Task<void> webgpuFlow() {
+    wgpu::Instance instance = wgpu::CreateInstance();
+    auto executor = co_await coro::currentExecutor;
+
+    bool done = false;
+    executor->schedule(pumpEvents(instance, done));
+
+    EXPECT_TRUE(instance);
+    if (!instance) co_return;
+
+    wgpu::Adapter adapter = co_await coro::wgpu::RequestAdapter(instance);
+    EXPECT_TRUE(adapter);
+    if (!adapter) co_return;
+
+    wgpu::AdapterInfo info {};
+    adapter.GetInfo(&info);
+    EXPECT_NE(info.backendType, wgpu::BackendType::Null);
+    if (info.backendType == wgpu::BackendType::Null) co_return;
+
+    wgpu::Device device = co_await coro::wgpu::RequestDevice(adapter);
+    EXPECT_TRUE(device);
+    if (!device) co_return;
+
+    wgpu::Queue queue = device.GetQueue();
+    EXPECT_TRUE(queue);
+    if (!queue) co_return;
+
+    // Submit an empty batch and await its completion.
+    queue.Submit(0, nullptr);
+    co_await coro::wgpu::OnSubmittedWorkDone(queue);
+
+    // Round-trip a value through a host-visible buffer:
+    //   write -> queue -> map -> read.
+    constexpr std::uint32_t kPayload = 0xC0FFEE42;
+
+    wgpu::BufferDescriptor srcDesc {};
+    srcDesc.size = sizeof(std::uint32_t);
+    srcDesc.usage = wgpu::BufferUsage::CopySrc;
+    srcDesc.mappedAtCreation = true;
+    wgpu::Buffer srcBuffer = device.CreateBuffer(&srcDesc);
+    EXPECT_TRUE(srcBuffer);
+    if (!srcBuffer) co_return;
+    *static_cast<std::uint32_t*>(srcBuffer.GetMappedRange()) = kPayload;
+    srcBuffer.Unmap();
+
+    wgpu::BufferDescriptor dstDesc {};
+    dstDesc.size = sizeof(std::uint32_t);
+    dstDesc.usage = wgpu::BufferUsage::MapRead | wgpu::BufferUsage::CopyDst;
+    wgpu::Buffer dstBuffer = device.CreateBuffer(&dstDesc);
+    EXPECT_TRUE(dstBuffer);
+    if (!dstBuffer) co_return;
+
+    wgpu::CommandEncoder encoder = device.CreateCommandEncoder();
+    encoder.CopyBufferToBuffer(srcBuffer, 0, dstBuffer, 0, sizeof(std::uint32_t));
+    wgpu::CommandBuffer commands = encoder.Finish();
+    queue.Submit(1, &commands);
+
+    co_await coro::wgpu::MapAsync(dstBuffer, wgpu::MapMode::Read, 0, sizeof(std::uint32_t));
+
+    std::uint32_t roundTripped =
+        *static_cast<const std::uint32_t*>(dstBuffer.GetConstMappedRange(0, sizeof(std::uint32_t)));
+    EXPECT_EQ(roundTripped, kPayload);
+    dstBuffer.Unmap();
+
+    done = true;
+}
+
+} // namespace
+
+TEST(WebGpu, AsyncWrappers) {
+    auto executor = coro::SerialExecutor::create();
+    EXPECT_NO_THROW(executor->syncWait(webgpuFlow()));
+}

--- a/tests/wasm/CMakeLists.txt
+++ b/tests/wasm/CMakeLists.txt
@@ -1,19 +1,27 @@
 # Add the target
 set(MODULE_NAME coro_tests)
-add_executable(${MODULE_NAME} bindings.cpp)
+
+set(CORO_TESTS_SOURCES bindings.cpp webgpu_bindings.cpp)
+
+add_executable(${MODULE_NAME} ${CORO_TESTS_SOURCES})
 
 target_link_libraries(${MODULE_NAME} PRIVATE coro)
 
 # Add Embind-specific flags
-target_compile_options(${MODULE_NAME} PRIVATE -fwasm-exceptions)
+target_compile_options(${MODULE_NAME} PRIVATE
+    -fwasm-exceptions
+    --use-port=emdawnwebgpu
+)
+
 target_link_options(${MODULE_NAME} PRIVATE
     -sMODULARIZE=1
-    -sENVIRONMENT=node
+    -sENVIRONMENT=web,node
     -sALLOW_MEMORY_GROWTH=1
     -sEXPORT_NAME=createModule
     -lembind
     -fwasm-exceptions
     --no-entry
+    --use-port=emdawnwebgpu
 )
 
 add_custom_command(
@@ -28,6 +36,6 @@ add_custom_command(
 
 add_test(
     NAME coro_tests
-    COMMAND npm run test 
+    COMMAND npm run test
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/tests/wasm/bindings.cpp
+++ b/tests/wasm/bindings.cpp
@@ -1,6 +1,8 @@
 #include <emscripten/bind.h>
 #include <emscripten/emscripten.h>
 
+#include <numeric>
+
 // for testing purposes
 #define private protected
 #include <coro/coro.hpp>
@@ -168,6 +170,17 @@ coro::Task<void> testCustomPromiseCancellation() {
     co_await promise;
 }
 
+coro::Task<int> testCoroAll(bool fail) {
+    std::vector<coro::Task<int>> tasks;
+    tasks.push_back(sleepy<5>(fail));
+    tasks.push_back(sleepy<5>(false));
+    tasks.push_back(sleepy<5>(fail));
+    tasks.push_back(sleepy<5>(false));
+    tasks.push_back(sleepy<5>(fail));
+    std::vector<int> result = co_await coro::all(std::move(tasks));
+    co_return std::accumulate(result.begin(), result.end(), 0);
+}
+
 void registerExceptionTranslator() {
     coro::registerExceptionTranslator([](std::exception_ptr eptr) -> emscripten::val {
         try {
@@ -193,6 +206,7 @@ EMSCRIPTEN_BINDINGS(Test) {
             auto executor = TestExecutor::create();
             return executor->promise(sleepy<5>(false));
         });
+    emscripten::function("coroAllTask", +[](bool fail) { return coro::taskPromise(testCoroAll(fail)); });
     emscripten::function("executorCount", +[]() { return TestExecutor::executorCount; });
     emscripten::function("runStateDestroyed", +[]() { return TestExecutor::weakRunState.lock() == nullptr; });
 

--- a/tests/wasm/package-lock.json
+++ b/tests/wasm/package-lock.json
@@ -8,7 +8,8 @@
       "name": "coro_tests",
       "version": "1.0.0",
       "devDependencies": {
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "puppeteer": "^24.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1075,6 +1076,41 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1101,6 +1137,13 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1218,6 +1261,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1262,6 +1326,41 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-jest": {
@@ -1387,6 +1486,113 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1441,6 +1647,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -1532,6 +1748,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
       }
     },
     "node_modules/ci-info": {
@@ -1687,6 +1917,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -1724,10 +1981,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1767,6 +2034,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -1776,6 +2058,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -1807,6 +2096,26 @@
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1827,6 +2136,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1839,6 +2170,36 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/execa": {
@@ -1898,6 +2259,50 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1913,6 +2318,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fill-range": {
@@ -2003,6 +2418,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -2050,6 +2480,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -2058,6 +2516,33 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/import-local": {
@@ -2108,6 +2593,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -2945,6 +3440,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -3004,6 +3522,16 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -3075,6 +3603,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3088,6 +3623,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -3178,6 +3723,53 @@
         "node": ">=6"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -3231,6 +3823,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3361,6 +3960,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -3373,6 +3982,85 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.1.tgz",
+      "integrity": "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1608973",
+        "puppeteer-core": "24.43.1",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pure-rand": {
@@ -3513,6 +4201,47 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3562,6 +4291,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/string-length": {
@@ -3663,6 +4404,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -3724,6 +4503,16 @@
         "node": "*"
       }
     },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -3743,6 +4532,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -3766,6 +4562,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -3830,6 +4633,13 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3873,6 +4683,28 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -3965,6 +4797,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -3976,6 +4819,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/tests/wasm/package.json
+++ b/tests/wasm/package.json
@@ -7,6 +7,7 @@
     "test": "jest tests/"
   },
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "puppeteer": "^24.0.0"
   }
 }

--- a/tests/wasm/tests/simple.test.js
+++ b/tests/wasm/tests/simple.test.js
@@ -55,6 +55,23 @@ test("Lifetime", async () => {
     expect(coro.runStateDestroyed()).toBe(true);
 })
 
+test("CoroAll", async() => {
+    const task = coro.coroAllTask(false);
+    const answer = await Promise.race([task, sleep(300, 11)]);
+    expect(answer).toBe(5 * 42);
+
+    await coro.coroAllTask(true).then(
+        result => {
+            throw new Error(`The failingTask should throw, but got result: ${result}`);
+        },
+        error => {
+            expect(error).toBeInstanceOf(CustomError);
+            expect(error.name).toStrictEqual("CustomError");
+            expect(error.message).toStrictEqual("test error");
+        }
+    )
+})
+
 test("Cancellation", async () => {
     const task = coro.launchCancellableTask();
     let timer = sleep(50, 11);

--- a/tests/wasm/tests/webgpu.test.js
+++ b/tests/wasm/tests/webgpu.test.js
@@ -1,0 +1,109 @@
+// Real WebGPU tests. Node has no WebGPU implementation, so the wasm module is
+// loaded into headless Chrome (via puppeteer's bundled Chrome for Testing,
+// which runs on GitHub Actions runners). SwiftShader supplies a software
+// WebGPU adapter, so no physical GPU is required.
+
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+const puppeteer = require('puppeteer');
+
+const ROOT = path.resolve(__dirname, '..');
+const MIME = {
+    '.js': 'text/javascript',
+    '.wasm': 'application/wasm',
+};
+
+// Chrome can't fetch the .wasm over file://, so serve the module dir.
+function startServer() {
+    return new Promise((resolve) => {
+        const server = http.createServer((req, res) => {
+            if (req.url === '/') {
+                res.writeHead(200, {'Content-Type': 'text/html'});
+                res.end('<!doctype html><script src="coro_tests.js"></script>');
+                return;
+            }
+            if (req.url === '/favicon.ico') {
+                res.writeHead(204);
+                res.end();
+                return;
+            }
+            const file = path.join(ROOT, path.posix.normalize(req.url).replace(/^(\.\.[/\\])+/, ''));
+            fs.readFile(file, (err, data) => {
+                if (err) {
+                    res.writeHead(404);
+                    res.end();
+                    return;
+                }
+                res.writeHead(200, {'Content-Type': MIME[path.extname(file)] || 'application/octet-stream'});
+                res.end(data);
+            });
+        });
+        server.listen(0, '127.0.0.1', () => resolve(server));
+    });
+}
+
+let server;
+let browser;
+let page;
+
+beforeAll(async () => {
+    server = await startServer();
+    browser = await puppeteer.launch({
+        args: [
+            '--no-sandbox', // required on GitHub Actions runners
+            '--disable-setuid-sandbox',
+            '--enable-unsafe-webgpu',
+            '--enable-features=Vulkan',
+            '--use-webgpu-adapter=swiftshader', // software adapter, no GPU needed
+        ],
+    });
+    page = await browser.newPage();
+    page.on('console', (msg) => {
+        if (msg.type() === 'error') {
+            console.error(`browser: ${msg.text()}`);
+        }
+    });
+    const {port} = server.address();
+    await page.goto(`http://127.0.0.1:${port}/`);
+    await page.evaluate(async () => {
+        window.coro = await createModule();
+    });
+}, 120000);
+
+afterAll(async () => {
+    if (browser) {
+        await browser.close();
+    }
+    if (server) {
+        server.close();
+    }
+});
+
+describe("WebGpu (emdawnwebgpu in headless Chrome)", () => {
+    test("browser exposes a WebGPU adapter", async () => {
+        const haveAdapter = await page.evaluate(
+            async () => !!(navigator.gpu && await navigator.gpu.requestAdapter()));
+        expect(haveAdapter).toBe(true);
+    }, 60000);
+
+    test("RequestAdapter → RequestDevice chain succeeds", async () => {
+        const result = await page.evaluate(() => coro.testRequestAdapterAndDevice());
+        expect(result.haveDevice).toBe(true);
+    }, 60000);
+
+    test("compute dispatch round-trips through all awaitable wrappers", async () => {
+        const count = 128;
+        const result = await page.evaluate((n) => coro.testComputeRoundTrip(n), count);
+        expect(result).toHaveLength(count);
+        // The shader computes 2x + 1; anything else means the dispatch or the
+        // readback (OnSubmittedWorkDone/MapAsync) went wrong.
+        result.forEach((value, i) => expect(value).toBe(2 * i + 1));
+    }, 60000);
+
+    test("broken shader reports diagnostics and trips the error scope", async () => {
+        const result = await page.evaluate(() => coro.testShaderDiagnostics());
+        expect(result.errors).not.toBe("");
+        expect(result.scopeCaughtValidationError).toBe(true);
+    }, 60000);
+});

--- a/tests/wasm/webgpu_bindings.cpp
+++ b/tests/wasm/webgpu_bindings.cpp
@@ -1,0 +1,141 @@
+#include <coro/coro.hpp>
+#include <coro/emscripten/executor.hpp>
+#include <coro/helpers/webgpu_cpp.h>
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr char kComputeShader[] = R"(
+@group(0) @binding(0) var<storage, read_write> data: array<u32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3u) {
+    if (gid.x < arrayLength(&data)) {
+        data[gid.x] = data[gid.x] * 2u + 1u;
+    }
+}
+)";
+
+coro::Task<::wgpu::Device> requestDevice() {
+    ::wgpu::Instance instance = ::wgpu::CreateInstance();
+    if (!instance) {
+        throw coro::wgpu::Error {"wgpu::CreateInstance() failed"};
+    }
+    ::wgpu::Adapter adapter = co_await coro::wgpu::RequestAdapter(instance);
+    co_return co_await coro::wgpu::RequestDevice(adapter);
+}
+
+coro::Task<emscripten::val> testRequestAdapterAndDevice() {
+    ::wgpu::Device device = co_await requestDevice();
+    emscripten::val out = emscripten::val::object();
+    out.set("haveDevice", static_cast<bool>(device));
+    co_return out;
+}
+
+/**
+ * End-to-end compute dispatch driving every awaitable wrapper on the happy
+ * path: RequestAdapter → RequestDevice → GetCompilationInfo →
+ * CreateComputePipelineAsync → OnSubmittedWorkDone → MapAsync. The shader
+ * maps each u32 to `2x + 1`; the mapped-back results are returned as a JS
+ * array so the test can verify the GPU actually ran the work.
+ */
+coro::Task<emscripten::val> testComputeRoundTrip(uint32_t count) {
+    ::wgpu::Device device = co_await requestDevice();
+    ::wgpu::Queue queue = device.GetQueue();
+
+    ::wgpu::ShaderSourceWGSL wgsl;
+    wgsl.code = kComputeShader;
+    ::wgpu::ShaderModuleDescriptor moduleDesc {.nextInChain = &wgsl};
+    ::wgpu::ShaderModule module = device.CreateShaderModule(&moduleDesc);
+    auto [errors, warnings] = co_await coro::wgpu::GetCompilationInfo(module);
+    if (!errors.empty()) {
+        throw coro::wgpu::Error {errors};
+    }
+
+    ::wgpu::ComputePipelineDescriptor pipelineDesc;
+    pipelineDesc.compute.module = module;
+    pipelineDesc.compute.entryPoint = "main";
+    ::wgpu::ComputePipeline pipeline = co_await coro::wgpu::CreateComputePipelineAsync(device, &pipelineDesc);
+
+    const uint64_t byteSize = uint64_t {count} * sizeof(uint32_t);
+    ::wgpu::BufferDescriptor storageDesc;
+    storageDesc.usage = ::wgpu::BufferUsage::Storage | ::wgpu::BufferUsage::CopySrc | ::wgpu::BufferUsage::CopyDst;
+    storageDesc.size = byteSize;
+    ::wgpu::Buffer storage = device.CreateBuffer(&storageDesc);
+
+    ::wgpu::BufferDescriptor readbackDesc;
+    readbackDesc.usage = ::wgpu::BufferUsage::MapRead | ::wgpu::BufferUsage::CopyDst;
+    readbackDesc.size = byteSize;
+    ::wgpu::Buffer readback = device.CreateBuffer(&readbackDesc);
+
+    std::vector<uint32_t> input(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        input[i] = i;
+    }
+    queue.WriteBuffer(storage, 0, input.data(), byteSize);
+
+    ::wgpu::BindGroupEntry entry;
+    entry.binding = 0;
+    entry.buffer = storage;
+    ::wgpu::BindGroupDescriptor bindGroupDesc;
+    bindGroupDesc.layout = pipeline.GetBindGroupLayout(0);
+    bindGroupDesc.entryCount = 1;
+    bindGroupDesc.entries = &entry;
+    ::wgpu::BindGroup bindGroup = device.CreateBindGroup(&bindGroupDesc);
+
+    ::wgpu::CommandEncoder encoder = device.CreateCommandEncoder();
+    ::wgpu::ComputePassEncoder pass = encoder.BeginComputePass();
+    pass.SetPipeline(pipeline);
+    pass.SetBindGroup(0, bindGroup);
+    pass.DispatchWorkgroups((count + 63) / 64);
+    pass.End();
+    encoder.CopyBufferToBuffer(storage, 0, readback, 0, byteSize);
+    ::wgpu::CommandBuffer commands = encoder.Finish();
+    queue.Submit(1, &commands);
+
+    co_await coro::wgpu::OnSubmittedWorkDone(queue);
+    co_await coro::wgpu::MapAsync(readback, ::wgpu::MapMode::Read, 0, byteSize);
+    const auto* mapped = static_cast<const uint32_t*>(readback.GetConstMappedRange(0, byteSize));
+    std::vector<uint32_t> output(mapped, mapped + count);
+    readback.Unmap();
+    co_return emscripten::val::array(output);
+}
+
+/**
+ * Failure path: compiles a deliberately broken shader inside a validation
+ * error scope and reports what GetCompilationInfo and PopErrorScope saw.
+ */
+coro::Task<emscripten::val> testShaderDiagnostics() {
+    ::wgpu::Device device = co_await requestDevice();
+
+    device.PushErrorScope(::wgpu::ErrorFilter::Validation);
+    ::wgpu::ShaderSourceWGSL wgsl;
+    wgsl.code = "fn broken( { this is not wgsl";
+    ::wgpu::ShaderModuleDescriptor moduleDesc {.nextInChain = &wgsl};
+    ::wgpu::ShaderModule module = device.CreateShaderModule(&moduleDesc);
+    auto [errors, warnings] = co_await coro::wgpu::GetCompilationInfo(module);
+    ::wgpu::ErrorType scopeError = co_await coro::wgpu::PopErrorScope(device);
+
+    emscripten::val out = emscripten::val::object();
+    out.set("errors", errors);
+    out.set("warningsAndInfo", warnings);
+    out.set("scopeCaughtValidationError", scopeError == ::wgpu::ErrorType::Validation);
+    co_return out;
+}
+
+} // namespace
+
+EMSCRIPTEN_BINDINGS(CoroWebGpuTests) {
+    emscripten::function("testRequestAdapterAndDevice",
+                         +[]() { return coro::taskPromise(testRequestAdapterAndDevice()); });
+    emscripten::function("testComputeRoundTrip",
+                         +[](uint32_t count) { return coro::taskPromise(testComputeRoundTrip(count)); });
+    emscripten::function("testShaderDiagnostics",
+                         +[]() { return coro::taskPromise(testShaderDiagnostics()); });
+}

--- a/third_party/FetchDawn.cmake
+++ b/third_party/FetchDawn.cmake
@@ -1,0 +1,69 @@
+# Download a prebuilt Dawn release into <CMAKE_CURRENT_LIST_DIR>/dawn.
+#
+# The version is hardcoded; to upgrade, pick a release from
+# https://github.com/google/dawn/releases and update the two variables below
+# (the sha is part of the asset file names). The next cmake run re-downloads.
+
+set(_dawn_version "v20260423.175430")
+set(_dawn_sha "31e25af254ab572c77054edec4946d2244e184dd")
+
+if(_FetchDawn_done)
+    return()
+endif()
+set(_FetchDawn_done TRUE)
+
+set(_dawn_root "${CMAKE_CURRENT_LIST_DIR}/dawn")
+set(_dawn_stamp "${_dawn_root}/.fetchdawn-version")
+
+set(_dawn_installed "")
+if(EXISTS "${_dawn_stamp}")
+    file(READ "${_dawn_stamp}" _dawn_installed)
+endif()
+
+if(NOT _dawn_installed STREQUAL "${_dawn_version}")
+    if(APPLE)
+        set(_dawn_platform "macos-latest")
+    elseif(UNIX)
+        set(_dawn_platform "ubuntu-latest")
+    else()
+        message(FATAL_ERROR "FetchDawn: unsupported host platform.")
+    endif()
+
+    set(_asset_name "Dawn-${_dawn_sha}-${_dawn_platform}-Release.tar.gz")
+    set(_asset_url "https://github.com/google/dawn/releases/download/${_dawn_version}/${_asset_name}")
+    set(_tarball "${CMAKE_CURRENT_BINARY_DIR}/${_asset_name}")
+
+    message(STATUS "FetchDawn: downloading ${_asset_name} (${_dawn_version})")
+    file(DOWNLOAD "${_asset_url}" "${_tarball}"
+         STATUS _dl_status
+         SHOW_PROGRESS
+         TLS_VERIFY ON)
+    list(GET _dl_status 0 _dl_code)
+    if(NOT _dl_code EQUAL 0)
+        file(REMOVE "${_tarball}")
+        message(FATAL_ERROR "FetchDawn: download of ${_asset_url} failed: ${_dl_status}")
+    endif()
+
+    set(_extract_dir "${CMAKE_CURRENT_BINARY_DIR}/dawn_extract")
+    file(REMOVE_RECURSE "${_extract_dir}")
+    file(ARCHIVE_EXTRACT INPUT "${_tarball}" DESTINATION "${_extract_dir}")
+    file(REMOVE "${_tarball}")
+
+    # Tarball layout: Dawn-<sha>-<platform>-Release/{include,lib,bin}/...
+    # Flatten that single top-level directory into ${_dawn_root}.
+    file(REMOVE_RECURSE "${_dawn_root}")
+    file(RENAME "${_extract_dir}/Dawn-${_dawn_sha}-${_dawn_platform}-Release" "${_dawn_root}")
+    file(REMOVE_RECURSE "${_extract_dir}")
+
+    file(WRITE "${_dawn_stamp}" "${_dawn_version}")
+    message(STATUS "FetchDawn: installed Dawn ${_dawn_version} into ${_dawn_root}")
+endif()
+
+# The ubuntu tarball installs the cmake package under lib64/, the others under lib/.
+if(EXISTS "${_dawn_root}/lib64/cmake/Dawn")
+    set(Dawn_DIR "${_dawn_root}/lib64/cmake/Dawn" CACHE PATH "Dawn cmake package dir" FORCE)
+else()
+    set(Dawn_DIR "${_dawn_root}/lib/cmake/Dawn" CACHE PATH "Dawn cmake package dir" FORCE)
+endif()
+find_package(Threads REQUIRED)
+find_package(Dawn REQUIRED CONFIG)


### PR DESCRIPTION
- Add wrapper functions for async webgpu functions allowing to co_await
  for the results instead of relying on callback mechanism implemented
  in dawn.
- Add tests for webgpu functionality and switch testing to run with
   pupeteer instead of node.