### PR TITLE
Allow multiple awaiters for a single task

### DIFF
--- a/include/coro/core/awaitable.hpp
+++ b/include/coro/core/awaitable.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "handle.hpp"
+#include "stop.hpp"
 #include "../detail/utils.hpp"
 
 #include <utility>
@@ -18,9 +19,10 @@ struct ReadyAwaitable {
     ReadyAwaitable(R&& r)
         : result(std::move(r)) {}
 
-    bool await_ready() noexcept {
+    constexpr bool await_ready() noexcept {
         return true;
     }
+
     void await_suspend(std::coroutine_handle<>) noexcept {}
 
     R await_resume() {
@@ -39,7 +41,7 @@ struct ReadyAwaitable<R&> {
     ReadyAwaitable(R& r)
         : result(r) {}
 
-    bool await_ready() noexcept {
+    constexpr bool await_ready() noexcept {
         return true;
     }
 
@@ -54,7 +56,7 @@ template <>
 struct ReadyAwaitable<void> {
     ReadyAwaitable() {}
 
-    bool await_ready() noexcept {
+    constexpr bool await_ready() noexcept {
         return true;
     }
     void await_suspend(std::coroutine_handle<>) noexcept {}
@@ -66,46 +68,32 @@ template <typename Task>
 struct Awaitable {
     using Return = Task::Type;
 
-    Awaitable(Task&& task)
-        : _task(std::move(task)) {}
+    Awaitable(Task&& task, StopToken stopToken)
+        : _task(std::move(task))
+        , _stopToken(std::move(stopToken)) {}
 
     Awaitable(Awaitable&&) = default;
 
     Awaitable& operator=(Awaitable&&) = default;
 
-    bool await_ready() const noexcept {
-        return false;
+    bool await_ready() noexcept {
+        return _task.ready();
     }
 
     template <typename Promise>
-    void await_suspend(std::coroutine_handle<Promise> awaiter) noexcept {
+    bool await_suspend(std::coroutine_handle<Promise> awaiter) noexcept {
         CoroHandle awaitingHandle = CoroHandle::fromTypedHandle(awaiter);
-        auto& awaitingPromise = awaiter.promise();
         auto& taskPromise = _task.promise();
-        if (taskPromise.executor == nullptr) {
-            // if task is not scheduled on any executor,
-            // copy awaiter task context and schedule on the same executor
-            taskPromise.executor = awaitingPromise.executor;
-            taskPromise.inheritContext(awaitingPromise);
-            // schedule new task via next() to ensure that the call hierarchy has precedence.
-            // This way scheduled tasks will work one by one rather then all at once with intermingled execution order.
-            taskPromise.executor->next(_task.handle());
-        } else if (taskPromise.executor != awaitingPromise.executor) {
-            // mark awaiter as waiting for external execution
-            awaitingPromise.executor->external(awaitingHandle);
-        }
-        taskPromise.set_continuation(std::move(awaitingHandle));
+        return taskPromise.add_awaiter(_task._handle, std::move(awaitingHandle));
     }
 
     Return await_resume() {
         // eagerly destroy completed task at the end of the scope
         detail::AtExit exit {[this]() noexcept { _task.reset(); }};
-
         // throw if stop was requested
-        auto& taskPromise = _task.promise();
-        taskPromise.continuation.throwIfStopped();
+        _stopToken.throwIfStopped();
 
-        if constexpr (std::is_move_constructible_v<Return>) {
+        if constexpr (!std::is_copy_constructible_v<Return>) {
             return std::move(_task.promise()).value();
         } else {
             return _task.promise().value();
@@ -114,6 +102,7 @@ struct Awaitable {
 
 private:
     Task _task;
+    StopToken _stopToken;
 };
 
 } // namespace coro

--- a/include/coro/core/promise.inl.hpp
+++ b/include/coro/core/promise.inl.hpp
@@ -6,11 +6,6 @@
 
 namespace coro {
 
-template <typename U>
-Awaitable<Task<U>> PromiseBase::await_transform(Task<U>&& task) {
-    return Awaitable<Task<U>> {std::move(task)};
-}
-
 template <typename R>
 Task<R> Promise<R>::get_return_object() {
     return Task<R>(CoroHandle::fromTypedHandle(handle_t::from_promise(*this)));

--- a/include/coro/core/promise_base.hpp
+++ b/include/coro/core/promise_base.hpp
@@ -7,7 +7,9 @@
 #include "task.fwd.hpp"
 #include "traits.hpp"
 
+#include <atomic>
 #include <mutex>
+#include <vector>
 
 namespace coro {
 
@@ -39,15 +41,24 @@ private:
 public:
     Executor::Ref executor;
     TaskContext context;
-    CoroHandle continuation = nullptr;
+
+private:
+    // A single awaiter is by far the most common case, so it is stored inline and the overflow storage
+    // allocates only for a task which is awaited more than once. std::vector is used because its default
+    // constructor is noexcept and hence can not allocate, unlike the deque behind std::queue.
+    // Both are valid only while the mutex is held.
+    CoroHandle _masterAwaiter;
+    std::vector<CoroHandle> _overflowAwaiters;
 
 protected:
     std::exception_ptr _exception;
-    ValueState _valueState;
+    ValueState _valueState = ValueState::Uninitialized;
 
 private:
     mutable std::mutex _mutex;
-    bool _finished = false;
+    // Read without the mutex, so that executors can query it from within their scheduling functions,
+    // which can be called while the mutex is held. Only ever goes from false to true.
+    std::atomic<bool> _finished = false;
     bool _inheritContext = true;
 
 public:
@@ -65,7 +76,7 @@ public:
 
     class FinalAwaiter {
     public:
-        bool await_ready() noexcept {
+        constexpr bool await_ready() noexcept {
             return false;
         }
 
@@ -89,9 +100,6 @@ public:
         emplace_exception(std::current_exception());
     }
 
-    template <typename U>
-    Awaitable<Task<U>> await_transform(Task<U>&& task);
-
     template <typename T>
     decltype(auto) await_transform(T&& obj) {
         using RawT = std::remove_cvref_t<T>;
@@ -99,16 +107,33 @@ public:
     }
 
 public:
-    void set_continuation(CoroHandle&& cont) {
+    bool add_awaiter(CoroHandle taskHandle, CoroHandle awaitingHandle) {
+        auto& awaitingPromise = awaitingHandle.promise();
         std::scoped_lock lock {_mutex};
-        continuation = std::move(cont);
         if (_finished) {
-            schedule_continuation();
+            return false;
         }
+        if (!_masterAwaiter) {
+            _masterAwaiter = awaitingHandle;
+        } else {
+            _overflowAwaiters.push_back(awaitingHandle);
+        }
+        if (executor == nullptr) {
+            // if task is not scheduled on any executor,
+            // copy awaitingHandle task context and schedule on the same executor
+            executor = awaitingPromise.executor;
+            inheritContext(awaitingPromise);
+            // schedule new task via next() to ensure that the call hierarchy has precedence.
+            // This way scheduled tasks will work one by one rather then all at once with intermingled execution order.
+            executor->next(taskHandle);
+        } else if (executor != awaitingPromise.executor) {
+            // mark awaitingHandle as waiting for external execution
+            awaitingPromise.executor->external(awaitingHandle);
+        }
+        return true;
     }
 
     bool finished() const {
-        std::scoped_lock lock {_mutex};
         return _finished;
     }
 
@@ -125,19 +150,31 @@ public:
 private:
     void on_finished() {
         std::scoped_lock lock {_mutex};
-        schedule_continuation();
         _finished = true;
+        if (!_masterAwaiter) {
+            return;
+        }
+        schedule_awaiter(std::move(_masterAwaiter));
+        for (auto& awaiter : _overflowAwaiters) {
+            schedule_awaiter(std::move(awaiter));
+        }
+        _overflowAwaiters.clear();
     }
 
-    void schedule_continuation() {
-        if (continuation) {
-            auto continuationExecutor = continuation.promise().executor;
-            if (continuationExecutor == executor) {
-                continuationExecutor->next(continuation);
-            } else {
-                continuationExecutor->schedule(continuation);
-            }
+    void schedule_awaiter(CoroHandle awaiter) {
+        auto awaiterExecutor = awaiter.promise().executor;
+        if (awaiterExecutor == executor) {
+            awaiterExecutor->next(std::move(awaiter));
+        } else {
+            awaiterExecutor->schedule(std::move(awaiter));
         }
+    }
+};
+
+template <typename T>
+struct await_ready_trait<Task<T>> {
+    static decltype(auto) await_transform(const PromiseBase& promise, Task<T> task) {
+        return Awaitable<Task<T>> {std::move(task), promise.context.stopToken};
     }
 };
 

--- a/include/coro/core/stop.hpp
+++ b/include/coro/core/stop.hpp
@@ -11,7 +11,7 @@
 
 namespace coro {
 
-class StopError : std::runtime_error {
+class StopError : public std::runtime_error {
 public:
     StopError()
         : std::runtime_error("Stop was requested via stop token.") {}

--- a/include/coro/core/task.hpp
+++ b/include/coro/core/task.hpp
@@ -26,9 +26,8 @@ public:
         : _handle(std::move(handle)) {}
 
 public:
-    // Move only
-    Task(const Task&) = delete;
-    Task& operator=(const Task&) = delete;
+    Task(const Task&) = default;
+    Task& operator=(const Task&) = default;
     Task(Task&&) = default;
     Task& operator=(Task&&) = default;
 

--- a/include/coro/detail/containers.hpp
+++ b/include/coro/detail/containers.hpp
@@ -47,16 +47,18 @@ public:
         return _deque.end();
     }
 
-    void erase(const std::remove_pointer_t<T>* el)
+    /// Returns the number of erased elements.
+    size_t erase(const std::remove_pointer_t<T>* el)
         requires std::is_pointer_v<T>
     {
-        std::erase(_deque, el);
+        return std::erase(_deque, el);
     }
 
-    void erase(const T& el)
+    /// Returns the number of erased elements.
+    size_t erase(const T& el)
         requires(!std::is_pointer_v<T>)
     {
-        std::erase(_deque, el);
+        return std::erase(_deque, el);
     }
 
 private:

--- a/include/coro/detail/sleep.hpp
+++ b/include/coro/detail/sleep.hpp
@@ -80,7 +80,7 @@ public:
     SleepAwaitable(uint32_t sleep)
         : _sleep(sleep) {}
 
-    bool await_ready() noexcept {
+    constexpr bool await_ready() noexcept {
         return false;
     }
 

--- a/include/coro/executors/serial_executor.hpp
+++ b/include/coro/executors/serial_executor.hpp
@@ -7,6 +7,7 @@
 #include <future>
 #include <mutex>
 #include <map>
+#include <thread>
 
 namespace coro {
 
@@ -72,6 +73,22 @@ public:
         return f.get();
     }
 
+    /**
+     * Blocks the calling thread while the executor has work to do, that is while there are queued tasks,
+     * a task being executed, or a task waiting for an external event.
+     * Returns immediately if the executor is already idle. Note that tasks scheduled from another thread
+     * after this call has returned are not accounted for.
+     * Must not be called from the executor thread itself, the queue can not drain while the thread
+     * draining it is blocked here.
+     */
+    void drain() {
+        if (std::this_thread::get_id() == _runningThread.get_id()) {
+            // would block forever, this is the thread which is supposed to drain the queue
+            std::abort();
+        }
+        _state->drain();
+    }
+
 protected:
     void schedule(CoroHandle coro) override {
         _state->schedule(std::move(coro));
@@ -105,13 +122,20 @@ private:
         detail::Deque<CoroHandle> tasks;
         std::map<CoroHandle, Callback::Ref> externals;
         std::condition_variable cv;
+        std::condition_variable idleCV;
         std::mutex mutex;
         std::atomic<bool> finished = false;
+        bool running = false;
 
         void schedule(CoroHandle&& handle) {
             {
                 std::scoped_lock lock {mutex};
                 externals.erase(handle);
+                if (handle.promise().finished()) [[unlikely]] {
+                    // nothing to execute, erasing it from the externals might have made the executor idle
+                    notifyIfIdle();
+                    return;
+                }
                 tasks.pushFront(std::move(handle));
             }
             cv.notify_one();
@@ -121,6 +145,11 @@ private:
             {
                 std::scoped_lock lock {mutex};
                 externals.erase(handle);
+                if (handle.promise().finished()) [[unlikely]] {
+                    // nothing to execute, erasing it from the externals might have made the executor idle
+                    notifyIfIdle();
+                    return;
+                }
                 tasks.pushBack(std::move(handle));
             }
             cv.notify_one();
@@ -141,12 +170,29 @@ private:
             promise.context.stopToken.addStopCallback(callback);
         }
 
+        void drain() {
+            std::unique_lock lock {mutex};
+            idleCV.wait(lock, [this] { return idle() || finished; });
+        }
+
+        /// Both must be called while the mutex is held.
+        bool idle() const {
+            return tasks.empty() && externals.empty() && !running;
+        }
+
+        void notifyIfIdle() {
+            if (idle()) {
+                idleCV.notify_all();
+            }
+        }
+
         void executorDestroyed() {
             {
                 std::scoped_lock lock {mutex};
                 finished = true;
             }
             cv.notify_one();
+            idleCV.notify_all();
         }
     };
 
@@ -154,7 +200,10 @@ private:
         // Runs in a separate thread
         while (true) {
             std::unique_lock lock {state->mutex};
+            // the task popped by the previous iteration, if any, is done executing by now
+            state->running = false;
             if (state->tasks.empty() && !state->finished) {
+                state->notifyIfIdle();
                 state->cv.wait(lock, [&state] { return !state->tasks.empty() || state->finished; });
             }
             if (state->finished) {
@@ -165,6 +214,7 @@ private:
                 break;
             }
             CoroHandle task = state->tasks.popBack().value();
+            state->running = true;
             // release lock and give a chance to schedule while task is being executed
             lock.unlock();
             // this can happen during cancellation, when coroutine waiting for external event

--- a/include/coro/helpers/all.hpp
+++ b/include/coro/helpers/all.hpp
@@ -33,7 +33,7 @@ template <typename... Args>
     requires(std::same_as<Args, void> && ...)
 Task<void> all(Task<Args>... tasks) {
     constexpr size_t count = sizeof...(tasks);
-    static_assert(count > 2, "It does not make sense to use coro::all() with <2 arguments...");
+    static_assert(count > 1, "It does not make sense to use coro::all() with one argument.");
     Latch latch {static_cast<std::ptrdiff_t>(count)};
     auto executor = co_await currentExecutor;
     std::exception_ptr eptr = nullptr;
@@ -56,7 +56,7 @@ template <typename T, typename... Args>
     requires(std::same_as<Args, T> && ... && !std::same_as<T, void>)
 Task<std::vector<T>> all(Task<T> first, Task<Args>... rest) {
     constexpr size_t count = 1 + sizeof...(rest);
-    static_assert(count > 2, "It does not make sense to use coro::all() with <2 arguments...");
+    static_assert(count > 1, "It does not make sense to use coro::all() with one argument.");
     std::vector<T> results(count);
     Latch latch {static_cast<std::ptrdiff_t>(count)};
     auto executor = co_await currentExecutor;
@@ -66,7 +66,7 @@ Task<std::vector<T>> all(Task<T> first, Task<Args>... rest) {
 
     executor->next(detail::runAndNotify(std::move(first), latch, eptr, &results[0]).setContext(promise.context));
     size_t idx = 1;
-    (executor->next(detail::runAndNotify(std::move(rest), latch, eptr, &results[idx++])).setContext(promise.context),
+    (executor->next(detail::runAndNotify(std::move(rest), latch, eptr, &results[idx++]).setContext(promise.context)),
      ...);
 
     // Reset stop token before awaiting for the latch, so we don't wake up from cancellation here when child tasks are
@@ -82,7 +82,7 @@ Task<std::vector<T>> all(Task<T> first, Task<Args>... rest) {
 template <typename... Args>
 Task<std::vector<std::any>> all(Task<Args>... tasks) {
     constexpr size_t count = sizeof...(tasks);
-    static_assert(count > 2, "It does not make sense to use coro::all() with <2 arguments...");
+    static_assert(count > 1, "It does not make sense to use coro::all() with one argument.");
 
     std::vector<std::any> results(count);
     Latch latch {static_cast<std::ptrdiff_t>(count)};

--- a/include/coro/helpers/task_or_value.hpp
+++ b/include/coro/helpers/task_or_value.hpp
@@ -104,9 +104,9 @@ namespace detail {
 
 template <typename R>
 struct TaskOrValueAwaitable {
-    TaskOrValueAwaitable(TaskOrValue<R>&& tv) {
+    TaskOrValueAwaitable(TaskOrValue<R>&& tv, StopToken stopToken) {
         if (tv.isTask()) {
-            _awaitable = Awaitable<Task<R>> {std::move(tv.task())};
+            _awaitable = Awaitable<Task<R>> {std::move(tv.task()), std::move(stopToken)};
         } else {
             if constexpr (std::is_same_v<R, void>) {
                 _awaitable = ReadyAwaitable<void> {};
@@ -117,12 +117,13 @@ struct TaskOrValueAwaitable {
     }
 
     bool await_ready() noexcept {
-        return !isTask();
+        return !isTask() || taskAwaitable().await_ready();
     }
 
     template <typename Promise>
-    void await_suspend(std::coroutine_handle<Promise> continuation) noexcept {
-        taskAwaitable().await_suspend(continuation);
+    bool await_suspend(std::coroutine_handle<Promise> continuation) noexcept {
+        // forward the result, awaited task might be already finished in which case it must not suspend
+        return taskAwaitable().await_suspend(continuation);
     }
 
     R await_resume() {
@@ -154,8 +155,8 @@ private:
 
 template <typename R>
 struct await_ready_trait<TaskOrValue<R>> {
-    static detail::TaskOrValueAwaitable<R> await_transform(const PromiseBase&, TaskOrValue<R>&& awaitable) {
-        return {std::move(awaitable)};
+    static detail::TaskOrValueAwaitable<R> await_transform(const PromiseBase& promise, TaskOrValue<R>&& awaitable) {
+        return {std::move(awaitable), promise.context.stopToken};
     }
 };
 

--- a/include/coro/sync/latch.hpp
+++ b/include/coro/sync/latch.hpp
@@ -51,7 +51,7 @@ private:
 
 namespace detail {
 
-class LatchState {
+class LatchState : public std::enable_shared_from_this<LatchState> {
 public:
     using Ref = std::shared_ptr<LatchState>;
 
@@ -129,9 +129,13 @@ private:
 };
 
 inline void LatchState::count_down(std::ptrdiff_t n) {
+    // A notified awaiter can drop the last Latch referring to this state. Declared before the lock, so that
+    // the state is destroyed after the mutex is released, and assigned only by the call which notifies.
+    LatchState::Ref self;
     std::scoped_lock lock {_mutex};
     _count -= n;
     if (_count <= 0) {
+        self = shared_from_this();
         while (true) {
             auto next = _awaiters.popFront().value_or(nullptr);
             if (!next) break;

--- a/include/coro/sync/mutex.hpp
+++ b/include/coro/sync/mutex.hpp
@@ -4,7 +4,6 @@
 #include "../core/promise_base.hpp"
 #include "../core/traits.hpp"
 #include "../detail/containers.hpp"
-#include "../detail/utils.hpp"
 
 #include <coroutine>
 
@@ -57,12 +56,19 @@ private:
             _locked = true;
             return false;
         }
-        _awaiters.push(awaiter);
+        _awaiters.pushBack(awaiter);
         return true;
     }
 
+    /// Dequeue an awaiter which is no longer interested in the lock, cancelled one for instance.
+    /// Returns whether it was still queued, meaning that the lock has not been passed to it.
+    bool dequeue(detail::MutexAwaitable* awaiter) {
+        std::scoped_lock lock {_mutex};
+        return _awaiters.erase(awaiter) != 0;
+    }
+
 private:
-    detail::Queue<detail::MutexAwaitable*> _awaiters;
+    detail::Deque<detail::MutexAwaitable*> _awaiters;
     mutable std::mutex _mutex;
     bool _locked = false;
 };
@@ -115,14 +121,21 @@ public:
     template <typename Promise>
     bool await_suspend(std::coroutine_handle<Promise> continuation) noexcept {
         _continuation = CoroHandle::fromTypedHandle(continuation);
-        const bool queued = _mutex->lock_or_queue(this);
-        if (queued) {
+        _queued = _mutex->lock_or_queue(this);
+        if (_queued) {
             _executor->external(_continuation);
         }
-        return queued;
+        return _queued;
     }
 
     ScopedLock await_resume() {
+        // Being resumed while still queued means the lock was never passed to us, so it must not be
+        // released here. Dequeueing under the mutex of the Mutex also settles the race against unlock().
+        if (_queued && _mutex->dequeue(this)) {
+            _stopToken.throwIfStopped();
+            // cancellation is the only thing which resumes a queued awaiter, should not reach here
+            std::abort();
+        }
         ScopedLock lock {_mutex};
         _stopToken.throwIfStopped();
         return lock;
@@ -139,13 +152,14 @@ private:
     Executor::Ref _executor;
     CoroHandle _continuation;
     StopToken _stopToken;
+    bool _queued = false;
 };
 
 } // namespace detail
 
 inline void Mutex::unlock() {
     std::scoped_lock lock {_mutex};
-    auto* awaiter = _awaiters.pop().value_or(nullptr);
+    auto* awaiter = _awaiters.popFront().value_or(nullptr);
     if (awaiter) {
         // since this is a first come first serve mutex
         // if there is an awaiter in the queue pass lock to it without unlocking

--- a/tests/linux/coro_all.cpp
+++ b/tests/linux/coro_all.cpp
@@ -62,6 +62,21 @@ TEST(CoroAll, MixedTasksAndSyncWait) {
     EXPECT_EQ(voidTaskCount, 3);
 }
 
+TEST(CoroAll, TwoTasks) {
+    auto executor = coro::SerialExecutor::create();
+
+    int voidTaskCount = 0;
+    executor->syncWait(coro::all(increment(voidTaskCount), increment(voidTaskCount)));
+    EXPECT_EQ(voidTaskCount, 2);
+
+    auto numbers = executor->syncWait(coro::all(returnNumber(10), returnNumber(20)));
+    EXPECT_EQ(numbers, (std::vector<int> {10, 20}));
+
+    auto mixed = executor->syncWait(coro::all(increment(voidTaskCount), returnNumber(30)));
+    EXPECT_EQ(voidTaskCount, 3);
+    EXPECT_EQ(std::any_cast<int>(mixed[1]), 30);
+}
+
 coro::Task<void> executeMixedTasks(std::vector<std::any>& results, int& voidTaskCount) {
     results = co_await coro::all(increment(voidTaskCount), returnNumber(123), increment(voidTaskCount));
 }

--- a/tests/linux/cross.cpp
+++ b/tests/linux/cross.cpp
@@ -80,3 +80,63 @@ TEST(Cross, Finished) {
     auto r = e->syncWait(finished());
     EXPECT_EQ(r, 42);
 }
+
+coro::Task<int> finishedMultipleAwaits() {
+    auto e = coro::SerialExecutor::create();
+    auto task = e->schedule(second());
+    co_await coro::sleep(200);
+    EXPECT_EQ(task.ready(), true);
+    // task is finished on another executor, both awaits resume without suspension
+    int r1 = co_await task;
+    int r2 = co_await task;
+    co_return r1 + r2;
+};
+
+TEST(Cross, FinishedMultipleAwaits) {
+    auto e = coro::SerialExecutor::create();
+    auto r = e->syncWait(finishedMultipleAwaits());
+    EXPECT_EQ(r, 84);
+}
+
+coro::Task<int> multipleAwaitersOnOtherExecutor() {
+    auto e = coro::SerialExecutor::create();
+    auto task = e->schedule(second());
+    // both awaiters live on the current executor, while the task runs on `e`,
+    // so each of them is marked as external and scheduled once the task is finished
+    auto results = co_await coro::all(task, task);
+    co_return results[0] + results[1];
+};
+
+TEST(Cross, MultipleAwaiters) {
+    auto e = coro::SerialExecutor::create();
+    auto r = e->syncWait(multipleAwaitersOnOtherExecutor());
+    EXPECT_EQ(r, 84);
+}
+
+std::atomic<int> sharedTaskCounter = 0;
+
+coro::Task<int> sharedTask() {
+    ++sharedTaskCounter;
+    co_await coro::sleep(100);
+    co_return 42;
+}
+
+coro::Task<int> awaitShared(coro::Task<int> task) {
+    co_return co_await task;
+}
+
+// Single task awaited both from its own executor and from another one, so that one awaiter is
+// a plain queue entry while the other is marked as external, and a single completion has to
+// wake up both of them.
+TEST(Cross, MixedAwaiterExecutors) {
+    auto own = coro::SerialExecutor::create();
+    auto other = coro::SerialExecutor::create();
+
+    auto task = own->schedule(sharedTask());
+    auto sameExecutor = own->future(awaitShared(task));
+    auto crossExecutor = other->future(awaitShared(task));
+
+    EXPECT_EQ(sameExecutor.get(), 42);
+    EXPECT_EQ(crossExecutor.get(), 42);
+    EXPECT_EQ(sharedTaskCounter, 1);
+}

--- a/tests/linux/lifetime.cpp
+++ b/tests/linux/lifetime.cpp
@@ -51,6 +51,10 @@ TEST(Simple, Lifetime) {
         result = executor->syncWait(std::move(task));
         EXPECT_EQ(*counter, 1);
     }
+    // syncWait() returns as soon as the task value is set, at which point the executor thread can still
+    // hold the last reference to the wrapper task and hence to the executor itself, so give it time.
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(100ms);
     // Make sure that executor was destroyed despite the fact that there are circular shared references
     // between executor and task promises.
     EXPECT_EQ(*counter, 0);

--- a/tests/linux/mutex.cpp
+++ b/tests/linux/mutex.cpp
@@ -13,6 +13,47 @@ coro::Task<void> advance(size_t& counter, coro::Mutex& mutex) {
     co_return;
 }
 
+coro::Task<void>
+criticalSection(coro::Mutex& mutex, std::atomic<int>& inside, std::atomic<int>& overall, uint32_t hold) {
+    auto lock = co_await mutex;
+    // fails if the lock was handed to more than one coroutine at a time
+    EXPECT_EQ(++inside, 1);
+    co_await coro::sleep(hold);
+    --inside;
+    ++overall;
+}
+
+TEST(Mutex, Cancellation) {
+    coro::Mutex mutex;
+    std::atomic<int> inside = 0;
+    std::atomic<int> overall = 0;
+
+    auto e1 = coro::SerialExecutor::create();
+    auto e2 = coro::SerialExecutor::create();
+    auto e3 = coro::SerialExecutor::create();
+
+    using namespace std::chrono_literals;
+    // takes the lock and keeps holding it while the others queue up
+    auto holder = e1->future(criticalSection(mutex, inside, overall, 300));
+    std::this_thread::sleep_for(50ms);
+    // queued first, gets the lock only once the holder releases it
+    auto queued = e2->future(criticalSection(mutex, inside, overall, 10));
+    std::this_thread::sleep_for(50ms);
+    // queued second and cancelled while waiting, so it never receives the lock
+    coro::StopSource ss;
+    auto cancelled = e3->future(criticalSection(mutex, inside, overall, 10).setStopToken(ss.token()));
+    std::this_thread::sleep_for(50ms);
+
+    ss.requestStop();
+    EXPECT_THROW(cancelled.get(), coro::StopError);
+
+    // cancelled awaiter must not be left in the queue, unlock() would use it after it is destroyed
+    holder.get();
+    queued.get();
+    EXPECT_EQ(inside, 0);
+    EXPECT_EQ(overall, 2);
+}
+
 TEST(Mutex, CrossExecutorDataRace) {
     coro::Mutex mutex;
     size_t counter = 0;

--- a/tests/linux/simple.cpp
+++ b/tests/linux/simple.cpp
@@ -140,3 +140,151 @@ TEST(Simple, ThrowingVoidReturn) {
         },
         MyError);
 }
+
+coro::Task<std::vector<int>> multipleAwaiters() {
+    auto task = calculate();
+    auto result = co_await coro::all(task, task);
+    co_return result;
+}
+
+TEST(Simple, MultipleAwaiters) {
+    auto e = coro::SerialExecutor::create();
+    auto result = e->syncWait(multipleAwaiters());
+    EXPECT_EQ(result.size(), 2);
+    EXPECT_EQ(result[0], 42);
+    EXPECT_EQ(result[1], 42);
+}
+
+coro::Task<void> sleepAndCount(std::atomic<int>& counter) {
+    co_await coro::sleep(20);
+    ++counter;
+}
+
+// blocks the executor thread, so the task is still executing while the queue is already empty
+coro::Task<void> blockAndCount(std::atomic<int>& counter) {
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(50ms);
+    ++counter;
+    co_return;
+}
+
+TEST(Simple, Drain) {
+    auto e = coro::SerialExecutor::create();
+    std::atomic<int> counter = 0;
+    for (int i = 0; i < 5; ++i) {
+        e->schedule(sleepAndCount(counter));
+    }
+    // queued tasks are not done yet, sleeping ones are registered as external
+    e->drain();
+    EXPECT_EQ(counter, 5);
+    // already idle, must return right away
+    e->drain();
+    EXPECT_EQ(counter, 5);
+
+    counter = 0;
+    e->schedule(blockAndCount(counter));
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(10ms);
+    // queue is empty by now, but the task is still executing
+    e->drain();
+    EXPECT_EQ(counter, 1);
+}
+
+size_t countedCalculateCounter = 0;
+
+coro::Task<int> countedCalculate() {
+    ++countedCalculateCounter;
+    co_await coro::sleep(10);
+    co_return 42;
+}
+
+coro::Task<int> awaitTwice() {
+    auto task = countedCalculate();
+    // second co_await hits the already finished task, so it is resumed without suspension
+    int first = co_await task;
+    int second = co_await task;
+    co_return first + second;
+}
+
+TEST(Simple, RepeatedAwait) {
+    countedCalculateCounter = 0;
+    auto e = coro::SerialExecutor::create();
+    EXPECT_EQ(e->syncWait(awaitTwice()), 84);
+    // task body is executed only once, no matter how many times it is awaited
+    EXPECT_EQ(countedCalculateCounter, 1);
+}
+
+coro::Task<std::vector<int>> threeAwaiters() {
+    auto task = countedCalculate();
+    co_return co_await coro::all(task, task, task);
+}
+
+TEST(Simple, MultipleAwaitersRunOnce) {
+    countedCalculateCounter = 0;
+    auto e = coro::SerialExecutor::create();
+    auto result = e->syncWait(threeAwaiters());
+    EXPECT_EQ(result, (std::vector<int> {42, 42, 42}));
+    EXPECT_EQ(countedCalculateCounter, 1);
+}
+
+coro::TaskOrValue<int> wrapTask(coro::Task<int> task) {
+    return std::move(task);
+}
+
+coro::Task<int> awaitFinishedTaskOrValue() {
+    auto task = countedCalculate();
+    int first = co_await task;
+    // TaskOrValue does not check whether the wrapped task is finished in its await_ready(),
+    // so awaiting a finished task must be handled by the await_suspend() result
+    int second = co_await wrapTask(task);
+    co_return first + second;
+}
+
+TEST(Simple, FinishedTaskOrValue) {
+    countedCalculateCounter = 0;
+    auto e = coro::SerialExecutor::create();
+    EXPECT_EQ(e->syncWait(awaitFinishedTaskOrValue()), 84);
+    EXPECT_EQ(countedCalculateCounter, 1);
+}
+
+size_t throwingCounter = 0;
+
+coro::Task<int> throwingCalculate() {
+    ++throwingCounter;
+    co_await coro::sleep(10);
+    throw MyError {"multiple awaiters"};
+}
+
+coro::Task<int> catchTwice() {
+    auto task = throwingCalculate();
+    int caught = 0;
+    for (int i = 0; i < 2; ++i) {
+        try {
+            co_await task;
+        } catch (const MyError&) {
+            ++caught;
+        }
+    }
+    co_return caught;
+}
+
+coro::Task<void> allOfThrowing() {
+    auto task = throwingCalculate();
+    co_await coro::all(task, task);
+}
+
+TEST(Simple, MultipleAwaitersError) {
+    {
+        throwingCounter = 0;
+        auto e = coro::SerialExecutor::create();
+        // stored exception is rethrown for every awaiter, including the ones awaiting a finished task
+        EXPECT_EQ(e->syncWait(catchTwice()), 2);
+        EXPECT_EQ(throwingCounter, 1);
+    }
+    {
+        throwingCounter = 0;
+        auto e = coro::SerialExecutor::create();
+        EXPECT_THROW(e->syncWait(allOfThrowing()), MyError);
+        EXPECT_EQ(throwingCounter, 1);
+    }
+}

--- a/tests/linux/stop.cpp
+++ b/tests/linux/stop.cpp
@@ -108,6 +108,46 @@ TEST(Stop, StoppedToken) {
     EXPECT_EQ(exceptions[4][2], 0);
 }
 
+coro::Task<int> foreignTask() {
+    co_await coro::sleep(100);
+    co_return 42;
+}
+
+coro::Task<void> awaitForeignTask(coro::Task<int> task, int& stopErrors, int& otherErrors) {
+    try {
+        co_await task;
+    } catch (const coro::StopError&) {
+        ++stopErrors;
+    } catch (...) {
+        ++otherErrors;
+    }
+}
+
+// Awaited task runs on another executor and carries its own, never signaled stop token.
+// Cancelling the awaiter must surface StopError, so the stop token of the awaiter is the one to check.
+TEST(Stop, ForeignTaskToken) {
+    coro::StopSource inner;
+    coro::StopSource outer;
+    auto worker = coro::SerialExecutor::create();
+    auto executor = coro::SerialExecutor::create();
+
+    auto task = worker->schedule(foreignTask().setStopToken(inner.token()));
+    int stopErrors = 0;
+    int otherErrors = 0;
+    auto future = executor->future(awaitForeignTask(task, stopErrors, otherErrors).setStopToken(outer.token()));
+
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(30ms);
+    outer.requestStop();
+    future.get();
+    EXPECT_EQ(stopErrors, 1);
+    EXPECT_EQ(otherErrors, 0);
+
+    // let the foreign task finish, so its executor drains before the test ends
+    worker->drain();
+    EXPECT_EQ(task.ready(), true);
+}
+
 coro::Task<int> resetTest() {
     co_await coro::sleep(100);
     co_return 42;

--- a/tests/wasm/tests/simple.test.js
+++ b/tests/wasm/tests/simple.test.js
@@ -86,7 +86,7 @@ test("Cancellation", async () => {
         },
         (error) => {
             expect(error).toBeInstanceOf(WebAssembly.Exception);
-            expect(error.message).toStrictEqual(["coro::StopError", undefined]);
+            expect(error.message).toStrictEqual(["coro::StopError", "Stop was requested via stop token."]);
         }
     );
 })


### PR DESCRIPTION
- Allow and enqueue multiple awaiters for a single task and schedule all
  awaiters when the task is done. In case of the multiple awaiters the
  task inherits the context from the first awaiter, so it is a race,
  unless the user explicitly set the task context which is planned to
  have multiple awaiters.
- Turn task's finished flag into atomic and check it without mutex lock
  allowing to preemptively drop finished tasks instead of scheduling and
  letting the scheduler to drop them.
- Fix data race in Latch between signaled 1 count latch destruction and
  latch's awaiter scheduling function raising in a simple usage in
  webgpu wrappers.
- Fix bug in Mutex when cancelling task awaiting for mutex lock would
  try to schedule destroyed awaiter and SIGSEGV
- Add drain() function to the SerialExecutor which locks current thread
  untill all tasks scheduled by the user are complete.